### PR TITLE
Fix ControlSignal is not serializable error.

### DIFF
--- a/src/pion_power_api/__init__.py
+++ b/src/pion_power_api/__init__.py
@@ -1,6 +1,6 @@
 """Pion Power API async client package."""
 
-__version__ = "2026.7.3"
+__version__ = "2026.7.6"
 
 from .client import PionPowerAPIClient
 from .device import Device

--- a/src/pion_power_api/client.py
+++ b/src/pion_power_api/client.py
@@ -336,13 +336,15 @@ class PionPowerAPIClient:
             _LOGGER.debug("Using test mode set_control_data response.")
             response = self.test_mode_data["set_control_data"]
         else:
+            signal_payload = signal.to_dict() if signal is not None and hasattr(signal, "to_dict") else signal
+
             body = {
                 "deviceCode": device_code,
                 "controlValueType": 1,
                 "signalId": signal_id,
                 "controlLevel": control_level,
                 "signalValue": signal_value,
-                "signalString": json.dumps(signal) if signal is not None else None,
+                "signalString": json.dumps(signal_payload) if signal_payload is not None else None,
             }
             response = await self.__post("/ControlDataServer/ControlData/SetControlData", json=body)
         return self.__raise_on_error(response, bool)

--- a/src/pion_power_api/device.py
+++ b/src/pion_power_api/device.py
@@ -67,7 +67,7 @@ class Device:
             f"hardware_version={self.hardware_version!r}, "
             f"software_version={self.software_version!r}, "
             f"upgrade_version={self.upgrade_version!r}, "
-            f"upgrade_progress={self.upgrade_progress!r}, "
+            f"upgrade_progress={self.upgrade_progress!r})"
         )
 
     def __eq__(self, other: object) -> bool:
@@ -139,7 +139,7 @@ class Device:
             product_code=str(data.get("ProductCode")),
             product_name=str(data.get("ProductName")),
             hardware_version=str(data.get("HardwareVersion")),
-            software_version=str(data.get("SoftwareVersion")) or str(data.get("SoftVersion")),
+            software_version=str(data.get("SoftwareVersion") or data.get("SoftVersion")),
             upgrade_version=str(data.get("UpgradeVersion")),
             upgrade_progress=str(data.get("UpgradeProgress")),
             client=client,
@@ -196,7 +196,32 @@ class Device:
         """
         return await self.client.get_device_stats(self.device_code)
 
-    async def charging_control(self, *charge: bool, power_watts: int, current: int, duration_hours: int) -> bool:
+    async def start_charging(self, power_watts: int, current: int, duration_hours: int) -> bool:
+        """
+        Start charging the device.
+
+        Args:
+            power_watts: The desired charging power in Watts.
+            current: The desired charging current in Amperes.
+            duration_hours: The duration of the charging operation in hours.
+
+        Returns:
+            True if the charging command was successful, False otherwise.
+
+        """
+        return await self._charging_control(power_watts, current, duration_hours, charge=True)
+
+    async def stop_charging(self) -> bool:
+        """
+        Stop charging the device.
+
+        Returns:
+            True if the stop charging command was successful, False otherwise.
+
+        """
+        return await self._charging_control(0, 0, 0, charge=False)
+
+    async def _charging_control(self, power_watts: int, current: int, duration_hours: int, *, charge: bool) -> bool:
         """
         Send a charging control command to the device.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import pytest
 import respx
@@ -10,6 +12,7 @@ from pion_power_api import (
     PionPowerAPIClient,
     PionUnexpectedResponseError,
 )
+from pion_power_api.control_signal import ControlSignal
 
 
 @respx.mock
@@ -579,6 +582,42 @@ async def test_set_control_data_with_signal():
 
     assert result is True
     assert route.called
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_set_control_data_with_control_signal():
+    """Test set_control_data with a ControlSignal object."""
+    route = respx.post(
+        "https://api.example.com/v1/ControlDataServer/ControlData/SetControlData"
+    ).mock(
+        return_value=httpx.Response(
+            200, json={"Code": 1, "Msg": "Success", "Data": True}
+        )
+    )
+
+    signal = ControlSignal(
+        pile_sn="DEV123",
+        start_time="2026-07-06 12:34:56",
+        duration=2,
+        current=16.0,
+        power=2500.0,
+        status=0,
+    )
+
+    async with PionPowerAPIClient(
+        "https://api.example.com/v1", "user@example.com", "password"
+    ) as client:
+        result = await client.set_control_data(
+            "DEV123", "90100205", 1, 16, signal=signal
+        )
+
+    assert result is True
+    assert route.called
+
+    request = route.calls[0].request
+    payload = json.loads(request.content.decode())
+    assert payload["signalString"] == json.dumps(signal.to_dict())
 
 
 @respx.mock

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,196 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pion_power_api.device import Device
+
+
+def make_device(client=None) -> Device:
+    if client is None:
+        client = MagicMock()
+    return Device(
+        station_code="STN001",
+        device_code="DEV001",
+        device_name="Test Device",
+        device_type="TypeA",
+        parent_code="PARENT001",
+        master_or_slave="Master",
+        device_share_status="Shared",
+        product_id="PID001",
+        product_code="PCODE001",
+        product_name="Product Name",
+        hardware_version="HW1.0",
+        software_version="SW2.0",
+        upgrade_version="UV3.0",
+        upgrade_progress="50%",
+        client=client,
+    )
+
+
+def test_device_from_dict_and_to_dict_roundtrip():
+    payload = {
+        "StationCode": "STN001",
+        "DeviceCode": "DEV001",
+        "DeviceName": "Test Device",
+        "DeviceType": "TypeA",
+        "ParentCode": "PARENT001",
+        "MasterOrSlave": "Master",
+        "DeviceShareStatus": "Shared",
+        "ProductId": "PID001",
+        "ProductCode": "PCODE001",
+        "ProductName": "Product Name",
+        "HardwareVersion": "HW1.0",
+        "SoftwareVersion": "SW2.0",
+        "UpgradeVersion": "UV3.0",
+        "UpgradeProgress": "50%",
+    }
+
+    client = MagicMock()
+    device = Device.from_dict(payload, client=client)
+
+    assert device.station_code == "STN001"
+    assert device.device_code == "DEV001"
+    assert device.software_version == "SW2.0"
+    assert device.to_dict() == payload
+    assert device.client is client
+
+
+def test_device_from_dict_uses_soft_version_fallback():
+    payload = {
+        "StationCode": "STN001",
+        "DeviceCode": "DEV001",
+        "DeviceName": "Test Device",
+        "DeviceType": "TypeA",
+        "ParentCode": "PARENT001",
+        "MasterOrSlave": "Master",
+        "DeviceShareStatus": "Shared",
+        "ProductId": "PID001",
+        "ProductCode": "PCODE001",
+        "ProductName": "Product Name",
+        "HardwareVersion": "HW1.0",
+        "SoftVersion": "SW-FALLBACK",
+        "UpgradeVersion": "UV3.0",
+        "UpgradeProgress": "50%",
+    }
+
+    device = Device.from_dict(payload, client=MagicMock())
+
+    assert device.software_version == "SW-FALLBACK"
+
+
+def test_device_equality_and_hash():
+    payload = {
+        "StationCode": "STN001",
+        "DeviceCode": "DEV001",
+        "DeviceName": "Test Device",
+        "DeviceType": "TypeA",
+        "ParentCode": "PARENT001",
+        "MasterOrSlave": "Master",
+        "DeviceShareStatus": "Shared",
+        "ProductId": "PID001",
+        "ProductCode": "PCODE001",
+        "ProductName": "Product Name",
+        "HardwareVersion": "HW1.0",
+        "SoftwareVersion": "SW2.0",
+        "UpgradeVersion": "UV3.0",
+        "UpgradeProgress": "50%",
+    }
+
+    device_a = Device.from_dict(payload, client=MagicMock())
+    device_b = Device.from_dict(payload, client=MagicMock())
+    device_c = Device.from_dict(
+        {**payload, "DeviceName": "Other Device"}, client=MagicMock()
+    )
+
+    assert device_a == device_b
+    assert hash(device_a) == hash(device_b)
+    assert device_a != device_c
+    assert device_a != "not a device"
+
+
+def test_device_repr_contains_device_code_and_station_code():
+    device = make_device()
+    repr_text = repr(device)
+
+    assert "Device(" in repr_text
+    assert "station_code='STN001'" in repr_text
+    assert "device_code='DEV001'" in repr_text
+    assert repr_text.endswith(")")
+
+
+@pytest.mark.asyncio
+async def test_get_realtime_data_delegates_to_client():
+    client = MagicMock()
+    client.get_realtime_data_by_device_code = AsyncMock(
+        return_value={"signal1": "value1"}
+    )
+    device = make_device(client=client)
+
+    result = await device.get_realtime_data()
+
+    assert result == {"signal1": "value1"}
+    client.get_realtime_data_by_device_code.assert_awaited_once_with("DEV001")
+
+
+@pytest.mark.asyncio
+async def test_get_stats_delegates_to_client():
+    client = MagicMock()
+    client.get_device_stats = AsyncMock(return_value="stats")
+    device = make_device(client=client)
+
+    result = await device.get_stats()
+
+    assert result == "stats"
+    client.get_device_stats.assert_awaited_once_with("DEV001")
+
+
+@pytest.mark.asyncio
+async def test_start_charging_sends_control_data():
+    mock_set_control = AsyncMock(return_value=True)
+    client = MagicMock()
+    client.set_control_data = mock_set_control
+    device = make_device(client=client)
+
+    result = await device.start_charging(power_watts=2500, current=16, duration_hours=4)
+
+    assert result is True
+    mock_set_control.assert_awaited_once()
+    args = mock_set_control.call_args.args
+    assert args[0] == "DEV001"
+    assert args[1] == "90100404"
+    assert args[2] == 1
+    assert args[3] == 0
+
+    signal = args[4]
+    assert signal.pile_sn == "DEV001"
+    assert signal.power == 2500
+    assert signal.current == 16
+    assert signal.duration == 4
+    assert signal.status == 0
+    assert isinstance(signal.start_time, str)
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_sends_stop_control_data():
+    mock_set_control = AsyncMock(return_value=True)
+    client = MagicMock()
+    client.set_control_data = mock_set_control
+    device = make_device(client=client)
+
+    result = await device.stop_charging()
+
+    assert result is True
+    mock_set_control.assert_awaited_once()
+    args = mock_set_control.call_args.args
+    assert args[0] == "DEV001"
+    assert args[1] == "90100404"
+    assert args[2] == 1
+    assert args[3] == 1
+
+    signal = args[4]
+    assert signal.pile_sn == "DEV001"
+    assert signal.power == 0
+    assert signal.current == 0
+    assert signal.duration == 0
+    assert signal.status == 1
+    assert isinstance(signal.start_time, str)


### PR DESCRIPTION
Fixes #12 

* Update set_control_data to call to_dict if the supplied object supports it.
* Update version to 2026.7.6
* Added more unit tests