### PR TITLE
Don't serialize None values

### DIFF
--- a/src/pion_power_api/control_signal.py
+++ b/src/pion_power_api/control_signal.py
@@ -52,16 +52,15 @@ class ControlSignal:
             Dictionary representation of the control signal with PascalCase keys.
 
         """
-        # The API expects string for StartTime and numeric for Power.
-        # Use empty string for missing StartTime and 0 for missing Power.
-        return {
+        values = {
             "PileSn": self.pile_sn,
-            "StartTime": self.start_time or "",
-            "Duration": self.duration or 0,
-            "Current": self.current or 0.0,
-            "Power": self.power if self.power is not None else 0,
+            "StartTime": self.start_time,
+            "Duration": self.duration,
+            "Current": self.current,
+            "Power": self.power,
             "Status": self.status,
         }
+        return {key: value for key, value in values.items() if value is not None}
 
     @classmethod
     def from_dict(cls, data: dict[str, t.Any]) -> ControlSignal:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -620,6 +620,22 @@ async def test_set_control_data_with_control_signal():
     assert payload["controlSend"][0]["signalString"] == json.dumps(signal.to_dict())
 
 
+def test_control_signal_to_dict_omits_none_values() -> None:
+    signal = ControlSignal(
+        pile_sn="DEV123",
+        status=0,
+        duration=None,
+        current=None,
+        power=None,
+        start_time=None,
+    )
+
+    assert signal.to_dict() == {
+        "PileSn": "DEV123",
+        "Status": 0,
+    }
+
+
 @respx.mock
 @pytest.mark.asyncio
 async def test_set_control_data_api_error():


### PR DESCRIPTION
Fixes #18

Update ControlSignal to omit None values in to_dict method and add corresponding test